### PR TITLE
Use time_t instead of __time_t.

### DIFF
--- a/main.c
+++ b/main.c
@@ -2896,7 +2896,7 @@ static char *histdata(bool rest, bool all)
 	int size = all ? 0 : confint("histviewsize");
 
 	int start = 0;
-	__time_t mtime = 0;
+	time_t mtime = 0;
 	for (int j = 2; j > 0; j--) for (int i = histfnum - 1; i >= 0; i--)
 	{
 		if (!rest && size && num >= size) break;


### PR DESCRIPTION
struct stat has the "member" st_mtime, which is a macro
to access st_mtim.tv_sec in struct timespec [1], and
tv_sec has type time_t [2].

This change is needed to successfully compile wyeb on NetBSD.

[1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html
[2] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/time.h.html